### PR TITLE
Update model name locale

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,7 @@
 en:
+  activerecord:
+    models:
+      solidus_affirm/gateway: Affirm
   spree:
     public_api_key: Public API Key
     private_api_key: Private API Key


### PR DESCRIPTION
Add gateway model name translation to en.yml. When listing payment
methods, the displayed name is typically
`payment_method.model_name.human` which uses the active translation
yaml. This ensures that affirm appears as `Affirm` in those lists as
opposed to `Gateway`.