### PR TITLE
Use escaped unicode for single quotes

### DIFF
--- a/app/helpers/affirm_helper.rb
+++ b/app/helpers/affirm_helper.rb
@@ -16,6 +16,6 @@ module AffirmHelper
       cancel_url: spree.cancel_affirm_url(payment_method_id: payment_method.id, order_id: order.id)
     }
     payload = SolidusAffirm::CheckoutPayload.new(order, config, metadata)
-    SolidusAffirm::Config.checkout_payload_serializer.new(payload, root: false).to_json
+    SolidusAffirm::Config.checkout_payload_serializer.new(payload, root: false).to_json.gsub("'","\u2019")
   end
 end

--- a/spec/helpers/affirm_helper_spec.rb
+++ b/spec/helpers/affirm_helper_spec.rb
@@ -2,13 +2,22 @@ require 'spec_helper'
 
 RSpec.describe AffirmHelper do
   describe "#affirm_payload_json" do
-    let(:order) { create(:order) }
+    let(:shipping_address) { create(:ship_address, firstname: "John's", lastname: "Do", zipcode: "52106-9133") }
+    let(:order) do
+      create(:order_with_line_items, ship_address: shipping_address)
+    end
     let(:payment_method) { create(:affirm_payment_gateway) }
     let(:metadata) { {} }
 
     it "calls the configured payload serializer" do
       expect(SolidusAffirm::Config.checkout_payload_serializer).to receive(:new)
       helper.affirm_payload_json(order, payment_method, metadata)
+    end
+
+    # regression spec for https://github.com/solidusio/solidus_affirm/issues/42
+    it "returns single quotes (') to unicode escaped right single quotation mark (’)" do
+      expect(helper.affirm_payload_json(order, payment_method, metadata)).to include "’"
+      expect(helper.affirm_payload_json(order, payment_method, metadata)).to_not include "'"
     end
   end
 end

--- a/spec/serializers/solidus_affirm/address_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/address_serializer_spec.rb
@@ -10,6 +10,14 @@ RSpec.describe SolidusAffirm::AddressSerializer do
       name_json = { "first" => "John", "last" => "Do" }
       expect(subject["name"]).to eql name_json
     end
+
+    context "with apostrophes in first or lastname" do
+      let(:address) { create(:address, firstname: "John's", lastname: "D'o", zipcode: "58451") }
+      it "will serialize correctly" do
+        name_json = { "first" => "John's", "last" => "D'o" }
+        expect(subject["name"]).to eql name_json
+      end
+    end
   end
 
   describe "address" do

--- a/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
@@ -167,4 +167,13 @@ RSpec.describe SolidusAffirm::CheckoutPayloadSerializer do
       end
     end
   end
+
+  context 'with apostrophes in name' do
+    let(:shipping_address) { create(:ship_address, firstname: "John's", lastname: "Do", zipcode: "52106-9133") }
+    it "renders a valid JSON" do
+      shipping_name_json = { "first" => "John's", "last" => "Do" }
+      expect(subject['shipping']["name"]).to eql shipping_name_json
+    end
+  end
+
 end


### PR DESCRIPTION
html data-attributes and javascript JSON parameters do not support
single quotes properly. This commit replaces all single quotes in the
Affirm data-attribute to the Unicoded escaped version. AMS already does this
out of the box for the & character. Making sure we do the same thing for single
quotes fixes the data and can properly create an Affirm payment now.

Fixes #42 