### PR TITLE
Render the json correctly

### DIFF
--- a/app/views/spree/checkout/payment/_affirm.html.erb
+++ b/app/views/spree/checkout/payment/_affirm.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: 'solidus_affirm/affirm_javascript' %>
 <%= javascript_include_tag "spree/frontend/affirm_checkout" %>
 
-<div id="affirm_checkout_payload" class="hidden" data-affirm='<%=raw(affirm_payload_json(current_order, payment_method))%>' data-paymentgateway='<%=SolidusAffirm::Gateway.first.id%>' />
+<div id="affirm_checkout_payload" class="hidden" data-affirm='<%=affirm_payload_json(current_order, payment_method)%>' data-paymentgateway='<%=SolidusAffirm::Gateway.first.id%>' />

--- a/spec/helpers/affirm_helper_spec.rb
+++ b/spec/helpers/affirm_helper_spec.rb
@@ -2,13 +2,21 @@ require 'spec_helper'
 
 RSpec.describe AffirmHelper do
   describe "#affirm_payload_json" do
-    let(:order) { create(:order) }
+    let(:shipping_address) { create(:ship_address, firstname: "John's", lastname: "Do", zipcode: "52106-9133") }
+    let(:order) do
+      create(:order_with_line_items, ship_address: shipping_address)
+    end
     let(:payment_method) { create(:affirm_payment_gateway) }
     let(:metadata) { {} }
 
     it "calls the configured payload serializer" do
       expect(SolidusAffirm::Config.checkout_payload_serializer).to receive(:new)
       helper.affirm_payload_json(order, payment_method, metadata)
+    end
+
+    # regression spec for https://github.com/solidusio/solidus_affirm/issues/42
+    it "returns valid JSON with quotes" do
+      expect(helper.affirm_payload_json(order, payment_method, metadata)).to include "'"
     end
   end
 end

--- a/spec/serializers/solidus_affirm/address_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/address_serializer_spec.rb
@@ -25,4 +25,12 @@ RSpec.describe SolidusAffirm::AddressSerializer do
       expect(subject["address"]).to eql address_json
     end
   end
+
+  context "with apostrophes in first or lastname" do
+    let(:address) { create(:address, firstname: "John's", lastname: "D'o", zipcode: "58451") }
+    it "will serialize correctly" do
+      name_json = { "first" => "John's", "last" => "D'o" }
+      expect(subject["name"]).to eql name_json
+    end
+  end
 end

--- a/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/checkout_payload_serializer_spec.rb
@@ -167,4 +167,12 @@ RSpec.describe SolidusAffirm::CheckoutPayloadSerializer do
       end
     end
   end
+
+  context 'with apostrophes in name' do
+    let(:shipping_address) { create(:ship_address, firstname: "John's", lastname: "Do", zipcode: "52106-9133") }
+    it "renders a valid JSON" do
+      shipping_name_json = { "first" => "John's", "last" => "Do" }
+      expect(subject['shipping']["name"]).to eql shipping_name_json
+    end
+  end
 end

--- a/spec/views/spree/checkout/payment/affirm_spec.rb
+++ b/spec/views/spree/checkout/payment/affirm_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe "payment/affirm" do
+  let(:payment_method) { create(:affirm_payment_gateway) }
+  let(:address) { create(:address, firstname: "John's", lastname: "D'o", zipcode: "58451") }
+  let(:order) { create(:order_with_totals, shipping_address: address) }
+
+  before do
+    allow(view).to receive_messages current_order: order
+    allow(view).to receive_messages payment_method: payment_method
+  end
+
+  it "renders valid json in html5 data attribute" do
+    render partial: "spree/checkout/payment/affirm"
+    rendered_partial = Nokogiri::HTML.fragment(rendered)
+    affirm_data_attribute = rendered_partial.css('div#affirm_checkout_payload')[0]["data-affirm"]
+    expect(affirm_data_attribute).to be_present
+    json = JSON.parse(affirm_data_attribute)
+    expect(json["shipping"]["name"]).to eql({"first"=>"John's", "last"=>"D'o"})
+  end
+end


### PR DESCRIPTION
When outputting the raw value there is a chance the output is invalid. For example when the name contains an apostrophe.

With the invalid JSON in the data attribute, affirm can't create the javascript object to create the payment.

This commit fixes that.

before:
<img width="320" alt="Screenshot 2020-03-20 at 13 01 32" src="https://user-images.githubusercontent.com/4252/77162367-1c4dc780-6aac-11ea-8025-157964887146.png">

after:
<img width="250" alt="Screenshot 2020-03-20 at 13 03 15" src="https://user-images.githubusercontent.com/4252/77162383-2374d580-6aac-11ea-8463-33ab9199ca53.png">


Fixes #42