### PR TITLE
Allow state to be nil

### DIFF
--- a/app/serializers/solidus_affirm/address_serializer.rb
+++ b/app/serializers/solidus_affirm/address_serializer.rb
@@ -16,7 +16,7 @@ module SolidusAffirm
         line1: object.address1,
         line2: object.address2,
         city: object.city,
-        state: object.state.abbr,
+        state: object.state&.abbr,
         zipcode: object.zipcode,
         country: object.country.iso3
       }

--- a/spec/serializers/solidus_affirm/address_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/address_serializer_spec.rb
@@ -33,4 +33,23 @@ RSpec.describe SolidusAffirm::AddressSerializer do
       expect(subject["name"]).to eql name_json
     end
   end
+
+  # This is a regression test that was added because previously the address
+  # serializer would error when the state was nil.
+  context "the country doesn't have states" do
+    let(:country) { create(:country, iso3: "VAT")}
+    let(:address) { create(:address, country: country, state: nil, zipcode: 10001) }
+
+    it "serializes the address" do
+      address_json = {
+        "line1" => "10 Lovely Street",
+        "line2" => "Northwest",
+        "city" => "Herndon",
+        "state" => nil,
+        "zipcode" => "10001",
+        "country" => "VAT"
+      }
+      expect(subject["address"]).to eql address_json
+    end
+  end
 end


### PR DESCRIPTION
I recently ran into an issue where the payment page would error if the address that the user entered did not have a state. This was because we were passing the address to solidus_affirm and the serializer would call `abbr` on the state which was nil in this case. I think all we need is a safe operator here to pass through nil if the state is nil.

The following are testing instructions for my clients store but I think I don't think we have meaningfully altered the checkout flow so it should work for any stock checkout I think.

Go to /checkout/address (with something in your cart)
Enter an address for a country without subregions (such as Vatican City)
Continue the checkout flow to the payment page
Previous behaviour: payment page errors with "undefined method `abbr' for nil:NilClass"
New behaviour: payment page works as normal

Let me know if you want me to file an issue to go along with this or if you need any more info. Thanks for reading and reviewing!
