### PR TITLE
Return charge id from capture

### DIFF
--- a/lib/solidus_affirm/affirm_client.rb
+++ b/lib/solidus_affirm/affirm_client.rb
@@ -26,7 +26,7 @@ module SolidusAffirm
     def capture(_money, charge_id, _options = {})
       response = ::Affirm::Charge.capture(charge_id)
       if response.success?
-        ActiveMerchant::Billing::Response.new(true, "Transaction Captured")
+        ActiveMerchant::Billing::Response.new(true, "Transaction Captured", {}, authorization: charge_id)
       else
         ActiveMerchant::Billing::Response.new(false, response.error.message)
       end

--- a/spec/lib/solidus_affirm/affirm_client_spec.rb
+++ b/spec/lib/solidus_affirm/affirm_client_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe SolidusAffirm::AffirmClient do
       end
     end
 
+    it "includes the charge_id" do
+      VCR.use_cassette("valid_capture") do
+        response = subject.capture(nil, charge_id, {})
+        expect(response.authorization).to eq charge_id
+      end
+    end
+
     context "with invalid data" do
       it "will return an unsuccesfull response" do
         VCR.use_cassette("invalid_capture") do


### PR DESCRIPTION
I recently found that there was an issue with how I implemented auto-capturing. With the way I structured it, if you use the purchase method then you authorize and capture at the same time. The issue is that this returns only the ActiveMerchant::Billing:Response from the purchase call which does not contain the id of the affirm payment. This means that the payment that is created will not have a response code and it will not be possible to refund or cancel payments.

This fixes that issues by including the id of the affirm payment in the response from capture which is also the response from purchase in affirm_client.rb

To test:
Follow the checkout flow and buy something using Affirm.
Find the order in the admin, navigate to payments, and refund the affirm payment.

Let me know what you think here. In my case I found that the payments that didn't have response codes were not too hard to fix because Affirm allows you to make an api request for changes 20 at a time and the response it gives includes the Solidus order number.