### PR TITLE
Prepare for Solidus 3.0

### DIFF
--- a/app/serializers/solidus_affirm/address_serializer.rb
+++ b/app/serializers/solidus_affirm/address_serializer.rb
@@ -5,10 +5,18 @@ module SolidusAffirm
     attributes :name, :address
 
     def name
-      {
-        first: object.firstname,
-        last: object.lastname
-      }
+      if SolidusSupport.combined_first_and_last_name_in_address?
+        full_name = Spree::Address::Name.new(object.name)
+        {
+          first: full_name.first_name,
+          last: full_name.last_name
+        }
+      else
+        {
+          first: object.first_name,
+          last: object.last_name
+        }
+      end
     end
 
     def address

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -4,7 +4,7 @@ require 'spree/core'
 
 module SolidusAffirm
   class Engine < Rails::Engine
-    include SolidusSupport::EngineExtensions::Decorators
+    include SolidusSupport::EngineExtensions
 
     isolate_namespace ::Spree
 

--- a/lib/solidus_affirm/engine.rb
+++ b/lib/solidus_affirm/engine.rb
@@ -17,7 +17,7 @@ module SolidusAffirm
 
     config.after_initialize do
       versions_without_api_custom_source_templates = Gem::Requirement.new('< 2.6')
-      if versions_without_api_custom_source_templates.satisfied_by?(SolidusSupport.solidus_gem_version)
+      if versions_without_api_custom_source_templates.satisfied_by?(Spree.solidus_gem_version)
         require_dependency 'solidus_affirm/backward_compatibility_hacks/api_template'
       end
     end

--- a/lib/solidus_affirm/factories/address_factory.rb
+++ b/lib/solidus_affirm/factories/address_factory.rb
@@ -1,0 +1,12 @@
+FactoryBot.modify do
+  factory :address do
+    if SolidusSupport.combined_first_and_last_name_in_address?
+      transient do
+        firstname { "John" }
+        lastname { "Doe" }
+      end
+
+      name { "#{firstname} #{lastname}" }
+    end
+  end
+end

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.author = 'Peter Berkenbosch'
   s.email = 'peter@stembolt.com'
-  s.homepage = 'https://stembolt.com/'
+  s.homepage = 'https://github.com/solidusio/solidus_affirm'
 
   if s.respond_to?(:metadata)
     s.metadata["homepage_uri"] = s.homepage if s.homepage

--- a/solidus_affirm.gemspec
+++ b/solidus_affirm.gemspec
@@ -30,8 +30,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'active_model_serializers', '~> 0.10'
   s.add_dependency 'affirm-ruby', '1.1.0'
-  s.add_dependency 'solidus_core', ['>= 2.0', '< 3']
-  s.add_dependency "solidus_support", '>= 0.2.2'
+  s.add_dependency 'solidus_core', ['>= 2.0', '< 4']
+  s.add_dependency "solidus_support", ['>= 0.8.1', '< 1']
 
   s.add_development_dependency 'solidus_dev_support'
   s.add_development_dependency 'vcr'

--- a/spec/requests/spree/api/orders_controller_spec.rb
+++ b/spec/requests/spree/api/orders_controller_spec.rb
@@ -17,7 +17,7 @@ describe Spree::Api::OrdersController, type: :request do
         let!(:order) { create(:order_ready_to_ship, payment_type: :captured_affirm_payment) }
 
         it "can be rendered correctly" do
-          if Gem::Requirement.new('>= 2.6').satisfied_by?(SolidusSupport.solidus_gem_version)
+          if Gem::Requirement.new('>= 2.6').satisfied_by?(Spree.solidus_gem_version)
             expect(response).to render_template partial: 'spree/api/payments/source_views/_affirm'
           else
             expect(response).to render_template 'spree/api/orders/show'

--- a/spec/serializers/solidus_affirm/line_item_serializer_spec.rb
+++ b/spec/serializers/solidus_affirm/line_item_serializer_spec.rb
@@ -25,23 +25,18 @@ RSpec.describe SolidusAffirm::LineItemSerializer do
 
   describe "item_image_url" do
     context "with variant specific image" do
-      before do
-        expect(line_item.variant).to receive(:images).and_return([create(:image)]).twice
-      end
-
       it "will return the variant image url" do
-        expect(subject['item_image_url']).to match /\/spree\/products\/\d\/large\/thinking-cat.jpg/
+        expect(line_item.variant).to receive(:images).and_return([create(:image)]).twice
+        expect(subject['item_image_url']).to match /(blank|thinking-cat).jpg/
       end
     end
 
     context "when the variant does not have an image" do
-      before do
-        expect(line_item.variant).to receive(:images).and_return([])
-        expect(line_item.variant.product).to receive(:images).and_return([create(:image)]).twice
-      end
+      before { allow(line_item.variant).to receive(:images).and_return([]) }
 
       it "will return the master product image url" do
-        expect(subject['item_image_url']).to match /\/spree\/products\/\d\/large\/thinking-cat.jpg/
+        expect(line_item.variant.product).to receive(:images).and_return([create(:image)]).twice
+        expect(subject['item_image_url']).to match /(blank|thinking-cat).jpg/
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,4 +21,10 @@ require 'solidus_affirm/factories'
 RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = false
+
+  if defined?(ActiveStorage::Current)
+    config.before(:all) do
+      ActiveStorage::Current.host = 'https://www.example.com'
+    end
+  end
 end


### PR DESCRIPTION
This PR prepares the extension to work on Solidus 3.0 by removing Solidus 2.11 deprecations that would become errors on 3.0.
